### PR TITLE
Rebinning single files

### DIFF
--- a/datamerge/mergecore.py
+++ b/datamerge/mergecore.py
@@ -216,6 +216,7 @@ class mergeCore:
         ready to be merged.
         """
         # nothing to do
+        cfgs = []
         if len(self.ranges) == 1:
             scattering_data = self.rangeObjUpdate(self.ranges[0])
             cfgs += [scattering_data.configuration]
@@ -226,7 +227,6 @@ class mergeCore:
                 ]
 
             # determine configurations that went in to the concatenated data:
-            cfgs = []
             for sd in scattering_data_per_range:
                 if sd.configuration != -1:
                     cfgs += [sd.configuration]

--- a/datamerge/readersandwriters.py
+++ b/datamerge/readersandwriters.py
@@ -63,8 +63,10 @@ def scatteringDataObjFromNX(
                 val = val.decode("utf-8")
 
             if key in readConfig.hdfDefaults:
-                if not isinstance(getattr(readConfig.hdfDefaults, key), np.ndarray):
+                if isinstance(val, np.ndarray) and val.size == 1:
                     val = val[0]  # numpy limitation: no longer casts arrays to scalars.
+                else:
+                    pass
 
             kvs.update({key: val})
     return scatteringDataObj(filename=filename, **kvs)


### PR DESCRIPTION
Use of datamerge to rebin files was broken by the latest mitigation of numpy deprecation issues. 

- the list holding configurations was not defined if there is only one range
- retrieval of the first element of `val` is working with the current changes, but the reasoning behind the original version is unclear to me. There is also a version 
```
-                if not isinstance(getattr(readConfig.hdfDefaults, key), np.ndarray):
+                if not isinstance(getattr(readConfig.hdfDefaults, key), np.ndarray) and isinstance(val, np.ndarray):
```
(not committed) in the version on `vsi-db`. I'd like to talk about this before changing this part. 

