### PR TITLE
Propagate QSigma if configured in the mergeConfig

### DIFF
--- a/datamerge/dataclasses.py
+++ b/datamerge/dataclasses.py
@@ -348,6 +348,11 @@ class HDFPathsObj(gimmeItems):
         validator=validators.instance_of(str),
         converter=str,
     )
+    QSigma: Optional[str] = field(
+        default="/entry/result/QSigma",
+        validator=validators.instance_of(str),
+        converter=str,
+    )
     sampleName: str = field(
         default="/entry1/sample/name",
         validator=validators.instance_of(str),

--- a/datamerge/dataclasses.py
+++ b/datamerge/dataclasses.py
@@ -349,8 +349,8 @@ class HDFPathsObj(gimmeItems):
         converter=str,
     )
     QSigma: Optional[str] = field(
-        default="/entry/result/QSigma",
-        validator=validators.instance_of(str),
+        default=None,
+        validator=validators.optional(validators.instance_of(str)),
         converter=str,
     )
     sampleName: str = field(

--- a/datamerge/mergecore.py
+++ b/datamerge/mergecore.py
@@ -670,9 +670,17 @@ class mergeCore:
                         ]
                     )
                     self.mData.QStd[binN] = DSQ.std
-                    self.mData.QSEM[binN] = DSQ.std * np.sqrt(
-                        (self.preMData.wt[lowerIndex:upperIndex] ** 2).sum()
-                        / (self.preMData.wt[lowerIndex:upperIndex].sum()) ** 2
+                    self.mData.QSEM[binN] = np.sqrt(
+                        (
+                            (
+                                (
+                                    self.preMData.QSigma[lowerIndex:upperIndex]
+                                    * self.preMData.wt[lowerIndex:upperIndex]
+                                )
+                                / (self.preMData.wt[lowerIndex:upperIndex].sum())
+                            )
+                            ** 2
+                        ).sum()
                     )
                     self.mData.QSigma[binN] = np.max(
                         [self.mData.QSEM[binN], DSQ.mean * self.mergeConfig.qeMin]

--- a/datamerge/mergecore.py
+++ b/datamerge/mergecore.py
@@ -670,18 +670,15 @@ class mergeCore:
                         ]
                     )
                     self.mData.QStd[binN] = DSQ.std
-                    self.mData.QSEM[binN] = np.sqrt(
+                    self.mData.QSEM[binN] = (
                         (
                             (
-                                (
-                                    self.preMData.QSigma[lowerIndex:upperIndex]
-                                    * self.preMData.wt[lowerIndex:upperIndex]
-                                )
-                                / (self.preMData.wt[lowerIndex:upperIndex].sum())
+                                self.preMData.QSigma[lowerIndex:upperIndex]
+                                * self.preMData.wt[lowerIndex:upperIndex]
                             )
                             ** 2
                         ).sum()
-                    )
+                    ) ** 0.5 / self.preMData.wt[lowerIndex:upperIndex].sum()
                     self.mData.QSigma[binN] = np.max(
                         [
                             self.mData.QStd[binN]

--- a/datamerge/mergecore.py
+++ b/datamerge/mergecore.py
@@ -683,7 +683,15 @@ class mergeCore:
                         ).sum()
                     )
                     self.mData.QSigma[binN] = np.max(
-                        [self.mData.QSEM[binN], DSQ.mean * self.mergeConfig.qeMin]
+                        [
+                            self.mData.QStd[binN]
+                            * np.sqrt(
+                                (self.preMData.wt[lowerIndex:upperIndex] ** 2).sum()
+                                / (self.preMData.wt[lowerIndex:upperIndex].sum()) ** 2
+                            ),
+                            self.mData.QSEM[binN],
+                            DSQ.mean * self.mergeConfig.qeMin,
+                        ]
                     )
                     self.mData.Mask[binN] = False
             return

--- a/datamerge/readersandwriters.py
+++ b/datamerge/readersandwriters.py
@@ -53,6 +53,10 @@ def scatteringDataObjFromNX(
                 val = h5f[hPath][()]
                 if isinstance(val, np.ndarray):
                     val = val.flatten()
+            elif hPath == "None":
+                logging.info(
+                    f"HDF5 Path for {key=} not configured, using default values for NeXus file {filename=}."
+                )
             else:
                 assert key in readConfig.hdfDefaults.keys(), logging.error(
                     f"NeXus file {filename=} does not contain information for {key=} at specified HDF5 Path {hPath}, filling in the default value."


### PR DESCRIPTION
Even if most of the data files do not have q uncertainty data at the moment, if they do I suggest to use error propagation to estimate the uncertainties of the binned q from the input QSigma. This is particularly relevant for SANS data. 

The error on the mean $`\bar{q} = \tfrac{\sum_{i} q_i w_i}{\sum_{i} w_i}`$ is calculated as: 
$$\Delta \bar{q} = \sqrt{\sum_i \left(\tfrac{\partial \bar{q}}{\partial q_i} \Delta q_i\right)^{2}} = \sqrt{\sum_i \left(\tfrac{w_i}{\sum_j w_j} \Delta q_i\right)^{2}} = \frac{\sqrt{\sum_i \left(w_i \Delta q_i\right)^{2}}}{\sum_i w_i}$$

As for ISigma, the largest error estimated is written to QSigma, this reproduces the previous behaviour if the standard deviation of points within a bin is larger (or no QSigma path is given in the mergeConfig). 